### PR TITLE
Use btoa and atob from window object if available

### DIFF
--- a/piexif.js
+++ b/piexif.js
@@ -631,6 +631,9 @@ SOFTWARE.
     };
 
 
+    if (typeof window !== "undefined" && typeof window.btoa === "function") {
+        var btoa = window.btoa;
+    }
     if (typeof btoa === "undefined") {
         var btoa = function (input) {        var output = "";
             var chr1, chr2, chr3, enc1, enc2, enc3, enc4;
@@ -665,6 +668,9 @@ SOFTWARE.
     }
     
     
+    if (typeof window !== "undefined" && typeof window.atob === "function") {
+        var atob = window.atob;
+    }
     if (typeof atob === "undefined") {
         var atob = function (input) {
             var output = "";


### PR DESCRIPTION
The `btoa` variable is declared with `var btoa = function ...`.  The `var` keyword causes a variable to be "hoisted" to the top of the function that it is declared in.  This means that `btoa` and `atob` are _always_ undefined in this library.  The code always falls back to the custom version of atob and btoa.

Normally this is not a problem.  However, with very big images the custom btoa and atob functions use a lot of memory (because big strings are created).

This change fixes the issue by explicitly checking for window.atob and window.btoa and relying on those if they are available.