### PR TITLE
add more exif checks when removing exif

### DIFF
--- a/piexif.js
+++ b/piexif.js
@@ -39,17 +39,12 @@ SOFTWARE.
         }
         
         var segments = splitIntoSegments(jpeg);
-        if (segments[1].slice(0, 2) == "\xff\xe1" && 
-               segments[1].slice(4, 10) == "Exif\x00\x00") {
-            segments = [segments[0]].concat(segments.slice(2));
-        } else if (segments[2].slice(0, 2) == "\xff\xe1" &&
-                   segments[2].slice(4, 10) == "Exif\x00\x00") {
-            segments = segments.slice(0, 2).concat(segments.slice(3));
-        } else {
-            throw("Exif not found.");
-        }
+        var newSegments = segments.filter(function(seg){
+          return  !(seg.slice(0, 2) == "\xff\xe1" &&
+                   seg.slice(4, 10) == "Exif\x00\x00"); 
+        });
         
-        var new_data = segments.join("");
+        var new_data = newSegments.join("");
         if (b64) {
             new_data = "data:image/jpeg;base64," + btoa(new_data);
         }


### PR DESCRIPTION
When using `piexif.remove`, I realized that it only checks two segments to see if there are exif tags. Yet, some images have exif tags in the latter segments. This causes that we can detect exif tags in `ExifReader` in `piexif.load` function, but `piexif.remove` will throw exception. I think it would be better to check all segments (similar to what `getExifSeg` function does.)