### PR TITLE
fix negative gps coordinates pack error

### DIFF
--- a/piexif.js
+++ b/piexif.js
@@ -2440,9 +2440,10 @@ SOFTWARE.
 
     that.GPSHelper = {
         degToDmsRational:function (degFloat) {
-            var minFloat = degFloat % 1 * 60;
+            var degAbs = Math.abs(degFloat);
+            var minFloat = degAbs % 1 * 60;
             var secFloat = minFloat % 1 * 60;
-            var deg = Math.floor(degFloat);
+            var deg = Math.floor(degAbs);
             var min = Math.floor(minFloat);
             var sec = Math.round(secFloat * 100);
 
@@ -2450,12 +2451,12 @@ SOFTWARE.
         },
 
         dmsRationalToDeg:function (dmsArray, ref) {
-          var sign = (ref === 'S' || ref === 'W') ? -1.0 : 1.0;
-          var deg = sign * dmsArray[0][0] / dmsArray[0][1] +
-                    dmsArray[1][0] / dmsArray[1][1] / 60.0 +
-                    dmsArray[2][0] / dmsArray[2][1] / 3600.0;
+            var sign = (ref === 'S' || ref === 'W') ? -1.0 : 1.0;
+            var deg = dmsArray[0][0] / dmsArray[0][1] +
+                      dmsArray[1][0] / dmsArray[1][1] / 60.0 +
+                      dmsArray[2][0] / dmsArray[2][1] / 3600.0;
 
-          return deg;
+            return deg * sign;
         }
     };
     


### PR DESCRIPTION
When testing the degToDmsRational and dmsRationalToDeg function with negative GPS coordinates, I stumbled upon an error : 
The DMS format isn't supposed to have negative values, resulting in an error when dumping the exif (inside the pack() call of the _dict_to_bytes() function)

To fix this I made sure to use the absolute value of the GPS coordinates inside the degToDmsRational function, and updated dmsRationalToDeg to comply with the changes.