### PR TITLE
Buffer() is deprecated

### DIFF
--- a/docs/sample.rst
+++ b/docs/sample.rst
@@ -218,5 +218,5 @@ Node.js
     var exifbytes = piexif.dump(exifObj);
 
     var newData = piexif.insert(exifbytes, data);
-    var newJpeg = new Buffer(newData, "binary");
+    var newJpeg = Buffer.from(newData, "binary");
     fs.writeFileSync(filename2, newJpeg);


### PR DESCRIPTION
(node:15707) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.