### PR TITLE
Wildcard to include all Typescript type files

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "files": [
     "dist/piexif.js",
     "dist/piexif.js.map",
-    "dist/index.d.ts",
+    "dist/*.d.ts",
     "LICENSE.txt",
     "README.md",
     "package.json"


### PR DESCRIPTION
The package.json excludes almost all Typescript files from the published NPM package, making it unusable when included in a Typescript project. This minor change will allow all type files to be included, thus fixing this issue.

This fixes issue #57 